### PR TITLE
Added bitly url shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Usage
 -----
 
 1. Go to the extension's options page
-    Window > Extensions > Amazon Affiliate Link Generator > Options
+    * Window > Extensions > Amazon Affiliate Link Generator > Options
 2. Put you tracking ID in the input field
-    Optimally select the shorten url checkbox and enter a bit.ly api key (https://bitly.com/a/oauth_apps)
+    * Optimally select the shorten url checkbox and enter a bit.ly api key (https://bitly.com/a/oauth_apps)
 3. Click Save
 4. Visit a product page on Amazon.com
 5. Click on the icon to see and copy your link

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Click on the icon to see and copy your link.
 Usage
 -----
 
-1. Go to the extension's options page  
+1. Go to the extension's options page
     Window > Extensions > Amazon Affiliate Link Generator > Options
 2. Put you tracking ID in the input field
+    Optimally select the shorten url checkbox and enter a bit.ly api key (https://bitly.com/a/oauth_apps)
 3. Click Save
 4. Visit a product page on Amazon.com
 5. Click on the icon to see and copy your link

--- a/cs.js
+++ b/cs.js
@@ -5,7 +5,7 @@ if (window == top) {
 }
 
 function findItemID() {
-  if (window.location.host === 'www.amazon.de') {
+  if (window.location.host === 'www.amazon.com') {
     var itemId = document.getElementsByName('ASIN.0')[0].value;
     console.log(itemId);
     return itemId;

--- a/options.html
+++ b/options.html
@@ -6,56 +6,48 @@
         <style>
             body {
                 font-family: 'Lucida Grande', sans-serif;
+                font-size: 16px;
                 color: hsl(210, 16%, 22%);
             }
-
             #content {
                 width: 600px;
                 margin: 0px auto;
             }
-
             #status {
                 display: hidden;
                 margin: 20px 0px;
             }
-
             #status span {
                 display: block;
                 width: 590px;
                 border-radius: 5px;
                 padding: 8px 5px;
             }
-
             .success {
                 border: 1px solid hsl(81,91%,31%);
                 background-color: hsl(81,91%,91%);
             }
-
             .error {
                 border: 1px solid hsl(0,64%,50%);
                 background-color: hsl(0,64%,90%);
             }
-
             header {
                 font-size: 75%;
                 border-bottom: 1px solid #EEEEEE;
                 margin-bottom: 20px;
             }
-
             #options {
                 font-size: 75%;
             }
-
             input[type="text"] {
-                border: 1px solid hsl(0, 0%, 75%);
                 border-radius: 2px;
+                border: 1px solid hsl(0, 0%, 75%);
                 box-sizing: border-box;
                 font: inherit;
-                height: 2em;
-                margin: 0;
-                padding: 3px;
+                margin: 10px 0;
+                padding: 6px;
+                width: 300px;
             }
-
             button {
                 margin-top: 14px;
                 background-color: silver;
@@ -75,11 +67,17 @@
                 text-shadow: 0 1px 0 hsl(0, 0%, 94%);
 
             }
-
             button:active {
                   background-image: -webkit-linear-gradient(#e7e7e7, #e7e7e7 38%, #d7d7d7);
                   box-shadow: none;
                   text-shadow: none;
+              }
+              label {
+                width: 120px;
+                display: inline-block;
+              }
+              #bitly-options {
+                display: none;
               }
         </style>
     </head>
@@ -88,12 +86,22 @@
         <header>
             <h1>Options for Amazon Affiliate Link Generator</h1>
         </header>
-        <div id="status">
-        </div>
+        <div id="status"></div>
         <div id="options">
-            <label for="tracking-id-text">Your tracking id:</label>
-            <input id="tracking-id-text" type="text" placeholder="homer-12" />
-            <br/>
+            <div>
+                <label for="tracking-id-text">Your tracking id:</label>
+                <input id="tracking-id-text" type="text" placeholder="homer-12">
+            </div>
+            <div>
+                <label for="shorten-url">Shorten Link?
+                    <input type="checkbox" id="shorten-url" value="1">
+                </label>
+            </div>
+            <div id="bitly-options">
+                <label for="bitly-api-key">Your tracking id:</label>
+                <input id="bitly-api-key" type="text" placeholder="jag4xlcllzjriyq...">
+            </div>
+
             <button id="saveButton">Save</button>
         </div>
     </div>

--- a/options.js
+++ b/options.js
@@ -3,6 +3,15 @@ function restoreOptions() {
     if (!trackId)
         return;
     $('#tracking-id-text').val(trackId);
+
+    var shortenUrl = localStorage['shortenUrl'];
+    if(shortenUrl == 1) {
+        $('#shorten-url').attr('checked', 'checked');
+
+        $('#bitly-api-key').val(localStorage['bitlyApiKey']);
+
+        $('#bitly-options').show();
+    }
 }
 
 function hideStatus() {
@@ -12,10 +21,18 @@ function hideStatus() {
 }
 
 function saveOptions() {
-    var trackId = $('#tracking-id-text').val();
-    console.log(trackId);
+    var trackId = $('#tracking-id-text').val(),
+        shortenUrl = $('#shorten-url').prop('checked') ? 1 : 0
+        bitlyApiKey = $('#bitly-api-key').val();
+
     if (trackId && trackId.length > 0) {
         localStorage['trackId'] = trackId;
+        localStorage['shortenUrl'] = shortenUrl;
+        if(shortenUrl == 0)
+            localStorage['bitlyApiKey'] = '';
+        else
+            localStorage['bitlyApiKey'] = bitlyApiKey;
+
         var successBlock = "<span class='success'>Options Saved</span>";
         $('#status').html(successBlock);
         $('#status').slideDown('slow', hideStatus());
@@ -26,8 +43,16 @@ function saveOptions() {
     }
 }
 
-$(document).ready(function(){
+$(document).ready(function() {
     $('#saveButton').click(saveOptions);
     restoreOptions();
+
+    $('#shorten-url').change(function() {
+        if($('#shorten-url').prop('checked')) {
+            $('#bitly-options').slideDown('fast');
+        } else {
+            $('#bitly-options').slideUp('fast');
+        }
+    });
 });
 

--- a/popup.js
+++ b/popup.js
@@ -6,8 +6,28 @@ window.onload = function() {
                 host = $.url(tablink).attr('host'),
                 link = 'http://' + host + '/dp/' + item + '/?tag='
                         + localStorage['trackId'];
+
             console.log(link);
-            $('#txt').val(link);
+            console.log(localStorage['shortenUrl']);
+
+            if(localStorage['shortenUrl'] == 1) {
+                var api_key = localStorage['bitlyApiKey'];
+
+                $.get(
+                    "https://api-ssl.bitly.com/v3/shorten",
+                    {
+                        "access_token" : api_key,
+                        "uri" : link,
+                        "format": "txt"
+                    },
+                    function(response) {
+                        $('#txt').val(response);
+                    }
+                );
+            } else {
+                $('#txt').val(link);
+            }
         });
     }
 }
+


### PR DESCRIPTION
I just found your extension and I wanted to add in the option to shorten a URL using bitly to mask the affiliate tag. Bitly uses the amzn.to url for short urls so it is not going to break affiliate association.

Also made some minor UI changes
